### PR TITLE
Fix Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>bitwarden/renovate-config"],
-  "enabledManagers": ["github-actions", "nuget", "dotnet-sdk"],
+  "enabledManagers": ["github-actions", "nuget"],
   "packageRules": [
     {
       "groupName": "gh minor",


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

The Renovate config is incorrect as `dotnet-sdk` is not one of the options available for managers.
